### PR TITLE
"how to use it" section added to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.egg-info
 build/
 dist/
+.tox/

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,10 @@ You can then enable the middleware in your `settings.py`::
         'scrapy_crawlera.CrawleraMiddleware': 600
     }
 
+
+Credentials
+===========
+
 There are two ways to specify credentials. 
 
 Through `settings.py`::
@@ -43,3 +47,19 @@ You got an APIKEY? Replace `CRAWLERA_USER` with it::
 
     CRAWLERA_USER = 'APIKEY'
     CRAWLERA_PASS = ''
+
+How to use it
+=============
+
+You just need to specify the headers when making a request like::
+
+    scrapy.Request(
+        'http://example.com',
+        headers={
+            'X-Crawlera-Max-Retries': 1,
+            ...
+        },
+    )
+
+Remember that you could also set which headers to use by default by all
+requests with `DEFAULT_REQUEST_HEADERS <http://doc.scrapy.org/en/1.0/topics/settings.html#default-request-headers>`_


### PR DESCRIPTION
adding a request example, and link to scrapy's default-request-headers