### PR TITLE
adding crawlera_apikey support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build/
 dist/
 .tox/
+venv/

--- a/README.rst
+++ b/README.rst
@@ -33,20 +33,13 @@ There are two ways to specify credentials.
 Through `settings.py`::
 
     CRAWLERA_ENABLED = True
-    CRAWLERA_USER = 'username'
-    CRAWLERA_PASS = 'password'
+    CRAWLERA_APIKEY = 'apikey'
 
 Through spider attributes::
 
     class MySpider:
         crawlera_enabled = True
-        crawlera_user = 'username'
-        crawlera_pass = 'password'
-
-You got an APIKEY? Replace `CRAWLERA_USER` with it::
-
-    CRAWLERA_USER = 'APIKEY'
-    CRAWLERA_PASS = ''
+        crawlera_apikey = 'apikey'
 
 How to use it
 =============

--- a/scrapy_crawlera.py
+++ b/scrapy_crawlera.py
@@ -23,6 +23,7 @@ class CrawleraMiddleware(object):
     preserve_delay = False
 
     _settings = [
+        ('apikey', str),
         ('user', str),
         ('pass', str),
         ('url', str),
@@ -54,7 +55,9 @@ class CrawleraMiddleware(object):
             self.url += '?noconnect'
 
         self._proxyauth = self.get_proxyauth(spider)
-        logging.info("Using crawlera at %s (user: %s)" % (self.url, self.user))
+        logging.info("Using crawlera at %s (user: %s)" % (
+            self.url,
+            self.apikey[:7] + '...' if self.apikey else self.user))
 
         if not self.preserve_delay:
             # Setting spider download delay to 0 to get maximum crawl rate
@@ -113,6 +116,8 @@ class CrawleraMiddleware(object):
 
     def get_proxyauth(self, spider):
         """Hook to compute Proxy-Authorization header by custom rules."""
+        if self.apikey:
+            return basic_auth_header(self.apikey, '')
         return basic_auth_header(self.user, getattr(self, 'pass'))
 
     def process_request(self, request, spider):

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -272,3 +272,19 @@ class CrawleraMiddlewareTestCase(TestCase):
         req1 = Request('http://www.scrapytest.org')
         self.assertEqual(mw1.process_request(req1, self.spider), None)
         self.assertEqual(req1.headers.get('X-Crawlera-Jobid'), '2816')
+
+    def test_apikey_assignment(self):
+        self.spider.crawlera_enabled = True
+
+        apikey = 'someapikey'
+        self.settings['CRAWLERA_APIKEY'] = None
+        self.settings['CRAWLERA_USER'] = apikey
+        self.settings['CRAWLERA_PASS'] = ''
+        proxyauth = basic_auth_header(apikey, '')
+        self._assert_enabled(self.spider, self.settings, proxyauth=proxyauth)
+
+        self.settings['CRAWLERA_USER'] = None
+        self.settings['CRAWLERA_APIKEY'] = apikey
+        self.settings['CRAWLERA_PASS'] = ''
+        proxyauth = basic_auth_header(apikey, '')
+        self._assert_enabled(self.spider, self.settings, proxyauth=proxyauth)


### PR DESCRIPTION
fixes #7 

The idea is to only add:

_settings_:
    
    CRAWLERA_APIKEY = 'someapikey'

_spider_:
    
    crawlera_apikey = 'someapikey'

no password needed, and this takes precedence over `CRAWLERA_USER`