### PR TITLE
update mware slot in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,14 +21,14 @@ You can then enable the middleware in your `settings.py`::
 
     DOWNLOADER_MIDDLEWARES = {
         ...
-        'scrapy_crawlera.CrawleraMiddleware': 600
+        'scrapy_crawlera.CrawleraMiddleware': 610
     }
 
 
 Credentials
 ===========
 
-There are two ways to specify credentials. 
+There are two ways to specify credentials.
 
 Through `settings.py`::
 


### PR DESCRIPTION
RedirectMiddleware is specified as being in slot 600 in the base settings.

It would be better if the readme here didn't recommend also using 600 for CrawleraMiddleware, because that leaves ordering of the mwares up to scrapy internals.

Since CrawleraMiddleware can modify delays, it is probably better for it to be > RedirectMiddleware, e.g. slot 610