### PR TITLE
Count session bans only once

### DIFF
--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -93,7 +93,7 @@ class CrawleraMiddlewareTestCase(TestCase):
             res = Response('http://unban.me')
             assert mw.process_response(req, res, spider) is res
             self.assertEqual(crawler.engine.fake_spider_closed_result, None)
-            self.assertEqual(mw._bans[None], 0)
+            self.assertEqual(mw._bans[None]['count'], 0)
 
         # check for not banning before maxbans for bancode
         for x in range(maxbans + 1):


### PR DESCRIPTION
If 25 requests are made with a single session (`X-Crawlera-Session`) and Crawlera receives a 503 for one of them, it will reply to the client with 503 for all of them (and all subsequent requests on that session).  The middleware will count 25 bans and this will cause the job to immediately die in the cloud.

Since there is a high delay between single session requests, it's unlikely that any of the other 25 requests had been sent (they were probably just queued) so the 503s received for those do not indicate actual bans.

The middleware should count this event as 1 ban and not kill the job.

This is an example fix, there may be a better way to do this.