### PR TITLE
Fix encoding of reported X-Crawlera-Error in stats

### DIFF
--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -152,7 +152,8 @@ class CrawleraMiddleware(object):
         crawlera_error = response.headers.get('X-Crawlera-Error')
         if crawlera_error:
             self.crawler.stats.inc_value('crawlera/response/error')
-            self.crawler.stats.inc_value('crawlera/response/error/%s' % crawlera_error)
+            self.crawler.stats.inc_value(
+                'crawlera/response/error/%s' % crawlera_error.decode('utf8'))
         return response
 
     def process_exception(self, request, exception, spider):


### PR DESCRIPTION
In Python 3, X-Crawlera-Errors appear in the stats represented as a bytes string, e.g:
`"crawlera/response/error/b'somethingbad'": 1`

This patch converts the header value to unicode when incrementing the stats counter.