### PR TITLE
Use CONNECT method to contact Crawlera proxy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-scrapy
+scrapy>=0.22
+six
 w3lib

--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -51,9 +51,6 @@ class CrawleraMiddleware(object):
         for k, type_ in self._settings:
             setattr(self, k, self._get_setting_value(spider, k, type_))
 
-        if '?noconnect' not in self.url:
-            self.url += '?noconnect'
-
         self._proxyauth = self.get_proxyauth(spider)
         logging.info("Using crawlera at %s (user: %s)" % (
             self.url,

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,6 @@ setup(
         'Topic :: Internet :: Proxy Servers',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Software Development :: Libraries :: Python Modules',
-    ]
+    ],
+    requires=['scrapy>=0.22', 'six', 'w3lib'],
 )

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setup(
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    requires=['scrapy>=0.22', 'six', 'w3lib'],
+    install_requires=['scrapy>=0.22', 'six', 'w3lib'],
 )

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -59,7 +59,7 @@ class CrawleraMiddlewareTestCase(TestCase):
 
     def _assert_enabled(self, spider,
                         settings=None,
-                        proxyurl='http://proxy.crawlera.com:8010?noconnect',
+                        proxyurl='http://proxy.crawlera.com:8010',
                         proxyauth=basic_auth_header('user', 'pass'),
                         maxbans=400,
                         download_timeout=190):
@@ -135,7 +135,7 @@ class CrawleraMiddlewareTestCase(TestCase):
     def test_proxyurl(self):
         self.spider.crawlera_enabled = True
         self.settings['CRAWLERA_URL'] = 'http://localhost:8010'
-        self._assert_enabled(self.spider, self.settings, proxyurl='http://localhost:8010?noconnect')
+        self._assert_enabled(self.spider, self.settings, proxyurl='http://localhost:8010')
 
     def test_proxyurl_including_noconnect(self):
         self.spider.crawlera_enabled = True


### PR DESCRIPTION
Scrapy can connect fine with Crawlera using CONNECT method.
I'm not 100% sure we need to have this on by default though. This could be switchable with a new `CRAWLERA_USE_HTTP_CONNECT` setting of some sort.