### PR TITLE
middleware.py: Add spider info for each logging

### DIFF
--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -57,14 +57,16 @@ class CrawleraMiddleware(object):
         self._proxyauth = self.get_proxyauth(spider)
         logging.info("Using crawlera at %s (user: %s)" % (
             self.url,
-            self.apikey[:7] + '...' if self.apikey else self.user))
+            self.apikey[:7] + '...' if self.apikey else self.user),
+            extra={'spider': spider})
 
         if not self.preserve_delay:
             # Setting spider download delay to 0 to get maximum crawl rate
             spider.download_delay = 0
             logging.info(
                 "CrawleraMiddleware: disabling download delays on Scrapy side to optimize delays introduced by Crawlera. "
-                "To avoid this behaviour you can use the CRAWLERA_PRESERVE_DELAY setting but keep in mind that this may slow down the crawl significantly")
+                "To avoid this behaviour you can use the CRAWLERA_PRESERVE_DELAY setting but keep in mind that this may slow down the crawl significantly",
+                extra={'spider': spider})
 
     def _settings_get(self, type_, *a, **kw):
         if type_ is int:


### PR DESCRIPTION
Add spider info for each logging by adding `extra` argument
to logging calls.

Closes https://github.com/scrapy-plugins/scrapy-crawlera/issues/46