### PR TITLE
[WIP] Add handling of default crawlera headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+.pytest_cache
 
 # Translations
 *.mo
@@ -68,3 +69,7 @@ target/
 
 # IDEA
 .idea/
+
+# Pipenv
+Pipfile*
+


### PR DESCRIPTION
:warning: STILL WORK IN PROGRESS :warning: 

I am opening this PR, to open a discussion on one thing @baitxo and I were noticing since joining crawlera.

It seems that the default behavior of Crawlera with regards to headers do not offer the best experience right now, more specifically, we usually have better results with the following:

```
'X-Crawlera-Cookies': 'disabled'
'X-Crawlera-Profile': 'desktop'
'Accept-Encoding': 'gzip, deflate'
```

So many issues are fixed simply by using this headers that it has been basically a standard support response.

Since changing the Headers default behavior would not be backwards compatible, my thinking was that by updating `scrapy-crawlera` to use these headers would reduce a lot of future support questions, simply by never having the problem, as well as improve new users experience. This of course could be extended to another languages libs.

This PR would introduce a new setting:

`CRAWLERA_HEADERS_ENABLE` (default to True), not sure if the best name

If set to False, current behavior would happen, else we override the headers, unless already provided by the request or if there is a conflict.

What I mean by conflict is that for instance, `X-Crawlera-UA` is deprecated and if provided we can't also have a `X-Crawlera-Profiles` headers. I don't think there are other conflicts of this type.
