### PR TITLE
enable spider attributes for the most common headers

### DIFF
--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -333,3 +333,20 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.assertEqual(crawler.stats.get_value('crawlera/response/status/{}'.format(mw.ban_code)), 1)
         self.assertEqual(crawler.stats.get_value('crawlera/response/banned'), 1)
         self.assertEqual(crawler.stats.get_value('crawlera/response/error/somethingbad'), 1)
+
+    def test_spider_attributes_headers(self):
+        self.spider.crawlera_enabled = True
+        self.spider.crawlera_profile = 'mobile'
+        self.spider.crawlera_max_retries = 10
+
+        crawler = self._mock_crawler(self.spider, None)
+        mw = self.mwcls.from_crawler(crawler)
+        mw.open_spider(self.spider)
+
+        req = Request('http://www.scrapytest.org')
+        out = mw.process_request(req, self.spider)
+        self.assertIsNone(out)
+        self.assertEqual(req.headers.get('X-Crawlera-Profile'), b'mobile')
+        self.assertEqual(req.headers.get('X-Crawlera-Max-Retries'), b'10')
+        self.assertIsNone(req.headers.get('X-Crawlera-Cookies'))
+        self.assertIsNone(req.headers.get('X-Crawlera-Debug'))


### PR DESCRIPTION
This PR fixes #53 by introducind support for Crawlera settings via spider attributes for some common headers, such as:

```python
class FooSpider(scrapy.Spider):
    name = 'foo'
    crawlera_profile = 'mobile'  # sets `X-Crawlera-Profile: mobile` header in all requests
    crawlera_debug = 'ua'  # sets `X-Crawlera-Debug: ua` header in all requests
    ...
```

I didn't add support to the full list of headers, as we are just starting the discussion here.


