### PR TITLE
[MRG+2] clean X-Crawlera-* headers when crawlera is disabled

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,6 +73,12 @@ Here we have an example of specifying a Crawlera header into a Scrapy request::
 Remember that you could also set which headers to use by default by all
 requests with `DEFAULT_REQUEST_HEADERS <http://doc.scrapy.org/en/1.0/topics/settings.html#default-request-headers>`_
 
+.. note:: Crawlera headers are removed from requests when the middleware is activated but Crawlera
+    is disabled. For example, if you accidentally disable Crawlera via ``crawlera_enabled = False``
+    but keep sending ``X-Crawlera-*`` headers in your requests, those will be removed from the
+    request headers.
+
+
 This Middleware also adds some configurable Scrapy Settings, check :ref:`the complete list here <settings>`.
 
 All the rest

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -342,7 +342,8 @@ class CrawleraMiddlewareTestCase(TestCase):
         headers = {
             'X-Crawlera-Debug': True,
             'X-Crawlera-Profile': 'desktop',
-            'User-Agent': 'Scrapy'
+            'User-Agent': 'Scrapy',
+            '': None,
         }
         req = Request('http://www.scrapytest.org', headers=headers)
         out = mw.process_request(req, spider)

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -333,3 +333,31 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.assertEqual(crawler.stats.get_value('crawlera/response/status/{}'.format(mw.ban_code)), 1)
         self.assertEqual(crawler.stats.get_value('crawlera/response/banned'), 1)
         self.assertEqual(crawler.stats.get_value('crawlera/response/error/somethingbad'), 1)
+
+    def _make_fake_request(self, spider, crawlera_enabled):
+        spider.crawlera_enabled = crawlera_enabled
+        crawler = self._mock_crawler(spider, self.settings)
+        mw = self.mwcls.from_crawler(crawler)
+        mw.open_spider(spider)
+        headers = {
+            'X-Crawlera-Debug': True,
+            'X-Crawlera-Profile': 'desktop',
+            'User-Agent': 'Scrapy'
+        }
+        req = Request('http://www.scrapytest.org', headers=headers)
+        out = mw.process_request(req, spider)
+        return req
+
+    def test_clean_headers_when_disabled(self):
+        req = self._make_fake_request(self.spider, crawlera_enabled=False)
+
+        self.assertNotIn(b'X-Crawlera-Debug', req.headers)
+        self.assertNotIn(b'X-Crawlera-Profile', req.headers)
+        self.assertIn(b'User-Agent', req.headers)
+
+    def test_clean_headers_when_enabled(self):
+        req = self._make_fake_request(self.spider, crawlera_enabled=True)
+
+        self.assertIn(b'X-Crawlera-Debug', req.headers)
+        self.assertIn(b'X-Crawlera-Profile', req.headers)
+        self.assertIn(b'User-Agent', req.headers)


### PR DESCRIPTION
## The problem

Users of this middleware may have settings like this in their spiders:

```python
custom_settings = {
    'DEFAULT_REQUEST_HEADERS': {
        'X-Crawlera-Profile': 'desktop',
        'X-Crawlera-Debug': 'ua',
    }
}
```

Or, what's even more difficult to track, their spiders can be full of requests passing Crawlera headers such as:

```python
yield Request(fancy_url, headers={'X-Crawlera-Profile': 'desktop'})
```

If, for some reason, they disable Crawlera via `crawlera_enabled = False`, the middleware does nothing with the request and such headers will be exposed to the website, which may not be the desired outcome.


## The fix

This PR fixes the issue by cleaning all the headers whose name start with `X-Crawlera-` when Crawlera is disabed.