### PR TITLE
[MRG + 1] Add DEFAULT_CRAWLERA_HEADERS settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+.pytest_cache
 
 # Translations
 *.mo
@@ -68,3 +69,6 @@ target/
 
 # IDEA
 .idea/
+
+# Pipenv
+Pipfile*

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -58,3 +58,12 @@ Default: ``False``
 
 If ``False`` Sets Scrapy's ``DOWNLOAD_DELAY`` to ``0``, making the spider to crawl faster. If set to ``True``, it will
 respect the provided ``DOWNLOAD_DELAY`` from Scrapy.
+
+CRAWLERA_DEFAULT_HEADERS
+-----------------------
+
+Default: ``{}``
+
+Default headers added only to crawlera requests. Headers defined on ``DEFAULT_REQUEST_HEADERS`` will take precedence as long as the ``CrawleraMiddleware`` is placed after the ``DefaultHeadersMiddleware``*. Headers set on the requests have precedence over the two settings.
+
+*This is the default behavior, ``DefaultHeadersMiddleware`` default priority is ``400`` and we recommend ``CrawleraMiddleware`` priority to be ``610``

--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -8,7 +8,6 @@ from w3lib.http import basic_auth_header
 from scrapy import signals
 from scrapy.resolver import dnscache
 from scrapy.exceptions import ScrapyDeprecationWarning
-from scrapy.utils.python import without_none_values
 from twisted.internet.error import ConnectionRefusedError, ConnectionDone
 
 
@@ -65,8 +64,7 @@ class CrawleraMiddleware(object):
                 "CrawleraMiddleware: disabling download delays on Scrapy side to optimize delays introduced by Crawlera. "
                 "To avoid this behaviour you can use the CRAWLERA_PRESERVE_DELAY setting but keep in mind that this may slow down the crawl significantly")
 
-        headers = without_none_values(self.crawler.settings.get('CRAWLERA_DEFAULT_HEADERS', {}))
-        self._headers = headers.items()
+        self._headers = self.crawler.settings.get('CRAWLERA_DEFAULT_HEADERS', {}).items()
 
     def _settings_get(self, type_, *a, **kw):
         if type_ is int:
@@ -220,6 +218,8 @@ class CrawleraMiddleware(object):
     def _set_crawlera_default_headers(self, request):
         has_crawlera_ua = 'X-Crawlera-UA' in request.headers
         for header, value in self._headers:
+            if value is None:
+                continue
             if has_crawlera_ua and header == 'X-Crawlera-Profile':
                 continue
             request.headers.setdefault(header, value)

--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -226,8 +226,8 @@ class CrawleraMiddleware(object):
         ]
         if all(h.lower() in lower_case_headers for h in self.conflicting_headers):
             logging.warn(
-                'The headers %s are conflicting, X-Crawlera-UA will be ignored. '
-                'Please check https://doc.scrapinghub.com/crawlera.html for '
-                'more information'
-                % str(self.conflicting_headers)
+                'The headers %s are conflicting on request %s. X-Crawlera-UA '
+                'will be ignored. Please check https://doc.scrapinghub.com/cr'
+                'awlera.html for more information'
+                % (str(self.conflicting_headers), request.url)
             )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-cov
+mock; python_version == '2.7'

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -382,3 +382,16 @@ class CrawleraMiddlewareTestCase(TestCase):
         assert mw.process_request(req, spider) is None
         self.assertEqual(req.headers['X-Crawlera-UA'], b'desktop')
         self.assertNotIn('X-Crawlera-Profile', req.headers)
+
+        # test ignore None headers
+        self.settings['CRAWLERA_DEFAULT_HEADERS'] = {
+            'X-Crawlera-Profile': None,
+            'X-Crawlera-Cookies': 'disable'
+        }
+        crawler = self._mock_crawler(spider, self.settings)
+        mw = self.mwcls.from_crawler(crawler)
+        mw.open_spider(spider)
+        req = Request('http://www.scrapytest.org/other')
+        assert mw.process_request(req, spider) is None
+        self.assertEqual(req.headers['X-Crawlera-Cookies'], b'disable')
+        self.assertNotIn('X-Crawlera-Profile', req.headers)

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -413,8 +413,9 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.assertEqual(req.headers['X-Crawlera-Profile'], b'desktop')
         mock_logger.warn.assert_called_with(
             "The headers ('X-Crawlera-Profile', 'X-Crawlera-UA') are conflictin"
-            "g, X-Crawlera-UA will be ignored. Please check https://doc.scraping"
-            "hub.com/crawlera.html for more information"
+            "g on request http://www.scrapytest.org/other. X-Crawlera-UA will b"
+            "e ignored. Please check https://doc.scrapinghub.com/crawlera.html "
+            "for more information"
         )
 
         # test it ignores case
@@ -425,6 +426,7 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.assertEqual(req.headers['X-Crawlera-Profile'], b'desktop')
         mock_logger.warn.assert_called_with(
             "The headers ('X-Crawlera-Profile', 'X-Crawlera-UA') are conflictin"
-            "g, X-Crawlera-UA will be ignored. Please check https://doc.scraping"
-            "hub.com/crawlera.html for more information"
+            "g on request http://www.scrapytest.org/other. X-Crawlera-UA will b"
+            "e ignored. Please check https://doc.scrapinghub.com/crawlera.html "
+            "for more information"
         )

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -1,4 +1,8 @@
-from unittest import TestCase, mock
+from unittest import TestCase
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from w3lib.http import basic_auth_header
 from scrapy.http import Request, Response
@@ -390,7 +394,7 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.assertEqual(req.headers['X-Crawlera-Cookies'], b'disable')
         self.assertNotIn('X-Crawlera-Profile', req.headers)
 
-    @mock.patch('scrapy_crawlera.middleware.logging')
+    @patch('scrapy_crawlera.middleware.logging')
     def test_crawlera_default_headers_conflicting_headers(self, mock_logger):
         spider = self.spider
         self.spider.crawlera_enabled = True


### PR DESCRIPTION
After discussion on https://github.com/scrapy-plugins/scrapy-crawlera/pull/54 it was clear that DEFAULT_CRAWLERA_HEADERS was the preferable way to handle crawlera specific headers.

After much thinking on https://github.com/scrapy-plugins/scrapy-crawlera/pull/52 I believe, for now, we shouldn't change default headers as it will not be backwards compatible.

This PR:

* introduces DEFAULT_CRAWLERA_HEADERS setting
* Closes https://github.com/scrapy-plugins/scrapy-crawlera/issues/53, https://github.com/scrapy-plugins/scrapy-crawlera/pull/54 and https://github.com/scrapy-plugins/scrapy-crawlera/pull/52

If you are ok with this, let me know and I will add documentation accordingly