### PR TITLE
Check Crawlera Error Header when checking bans

### DIFF
--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -134,12 +134,18 @@ class CrawleraMiddleware(object):
         else:
             self._clean_crawlera_headers(request)
 
+    def _is_banned(self, response):
+        return (
+            response.status == self.ban_code and
+            response.headers.get('X-Crawlera-Error') == 'banned'
+        )
+
     def process_response(self, request, response, spider):
         if not self._is_enabled_for_request(request):
             return response
         key = self._get_slot_key(request)
         self._restore_original_delay(request)
-        if response.status == self.ban_code:
+        if self._is_banned(response):
             self._bans[key] += 1
             if self._bans[key] > self.maxbans:
                 self.crawler.engine.close_spider(spider, 'banned')

--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -137,7 +137,7 @@ class CrawleraMiddleware(object):
     def _is_banned(self, response):
         return (
             response.status == self.ban_code and
-            response.headers.get('X-Crawlera-Error') == 'banned'
+            response.headers.get('X-Crawlera-Error') == b'banned'
         )
 
     def process_response(self, request, response, spider):

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -105,7 +105,7 @@ class CrawleraMiddlewareTestCase(TestCase):
             res = Response(
                 'http://ban.me/%d' % x,
                 status=self.bancode,
-                headers={'X-Crawlera-Error': 'banned'}
+                headers={'X-Crawlera-Error': 'banned'},
             )
             assert mw.process_response(req, res, spider) is res
 
@@ -240,7 +240,6 @@ class CrawleraMiddlewareTestCase(TestCase):
         mw.process_response(req, res, self.spider)
         self.assertEqual(slot.delay, delay)
         self.assertEqual(self.spider.download_delay, delay)
-
 
         # ban with retry-after
         retry_after = 1.5


### PR DESCRIPTION
Checking only the status code is not enough to know if the response coming from crawlera is a ban or not. I have added extra checks to prevent false positives.