### PR TITLE
adding consistency to dont_proxy when it is false

### DIFF
--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -174,7 +174,7 @@ class CrawleraMiddleware(object):
         dnscache.pop(urlparse(self.url).hostname, None)
 
     def _is_enabled_for_request(self, request):
-        return self.enabled and 'dont_proxy' not in request.meta
+        return self.enabled and not request.meta.get('dont_proxy', False)
 
     def _get_slot_key(self, request):
         return request.meta.get('download_slot')

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -78,7 +78,7 @@ class CrawleraMiddlewareTestCase(TestCase):
         res = Response(req.url)
         assert mw.process_response(req, res, spider) is res
 
-        # disabled if 'dont_proxy' is set
+        # disabled if 'dont_proxy=True' is set
         req = Request('http://www.scrapytest.org')
         req.meta['dont_proxy'] = True
         assert mw.process_request(req, spider) is None
@@ -372,7 +372,7 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.spider.crawlera_enabled = True
 
         self.settings['CRAWLERA_DEFAULT_HEADERS'] = {
-            'X-Crawlera-Profile': 'desktop'
+            'X-Crawlera-Profile': 'desktop',
         }
         crawler = self._mock_crawler(spider, self.settings)
         mw = self.mwcls.from_crawler(crawler)
@@ -384,7 +384,7 @@ class CrawleraMiddlewareTestCase(TestCase):
         # test ignore None headers
         self.settings['CRAWLERA_DEFAULT_HEADERS'] = {
             'X-Crawlera-Profile': None,
-            'X-Crawlera-Cookies': 'disable'
+            'X-Crawlera-Cookies': 'disable',
         }
         crawler = self._mock_crawler(spider, self.settings)
         mw = self.mwcls.from_crawler(crawler)
@@ -400,7 +400,7 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.spider.crawlera_enabled = True
 
         self.settings['CRAWLERA_DEFAULT_HEADERS'] = {
-            'X-Crawlera-Profile': 'desktop'
+            'X-Crawlera-Profile': 'desktop',
         }
         crawler = self._mock_crawler(spider, self.settings)
         mw = self.mwcls.from_crawler(crawler)
@@ -430,3 +430,14 @@ class CrawleraMiddlewareTestCase(TestCase):
             "e ignored. Please check https://doc.scrapinghub.com/crawlera.html "
             "for more information"
         )
+
+    def test_dont_proxy_false_does_nothing(self):
+        spider = self.spider
+        spider.crawlera_enabled = True
+        crawler = self._mock_crawler(spider, self.settings)
+        mw = self.mwcls.from_crawler(crawler)
+        mw.open_spider(spider)
+        req = Request('http://www.scrapytest.org/other')
+        req.meta['dont_proxy'] = False
+        assert mw.process_request(req, spider) is None
+        self.assertIsNotNone(req.meta.get('proxy'))


### PR DESCRIPTION
The normal behavior for `dont_proxy` was to always set it as `dont_proxy=True` to stop the Middleware from proxying the specified request. But this has been also working when `dont_proxy=False` which doesn't feel consistent to me.

Now when someone sets `dont_proxy=False` it will do nothing, the Middleware will behave as usual.