### PR TITLE
adding long_description into package setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,15 @@
 from setuptools import setup
 
+with open("README.rst") as f:
+    readme = f.read()
+
+
 setup(
     name='scrapy-crawlera',
     version='1.4.0',
     license='BSD',
     description='Crawlera middleware for Scrapy',
+    long_description=readme,
     maintainer='Raul Gallegos',
     maintainer_email='raul.ogh@gmail.com',
     author='Scrapinghub',


### PR DESCRIPTION
Our [pypi page](https://pypi.org/project/scrapy-crawlera/) isn't showing a description, which should be gotten from the `long_description` of the package.