### PR TITLE
[MRG + 1] Fix default crawlera headers

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.0
+current_version = 1.5.0
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -59,7 +59,7 @@ Default: ``False``
 If ``False`` Sets Scrapy's ``DOWNLOAD_DELAY`` to ``0``, making the spider to crawl faster. If set to ``True``, it will
 respect the provided ``DOWNLOAD_DELAY`` from Scrapy.
 
-DEFAULT_CRAWLERA_HEADERS
+CRAWLERA_DEFAULT_HEADERS
 -----------------------
 
 Default: ``{}``

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -59,7 +59,7 @@ Default: ``False``
 If ``False`` Sets Scrapy's ``DOWNLOAD_DELAY`` to ``0``, making the spider to crawl faster. If set to ``True``, it will
 respect the provided ``DOWNLOAD_DELAY`` from Scrapy.
 
-CRAWLERA_DEFAULT_HEADERS
+DEFAULT_CRAWLERA_HEADERS
 -----------------------
 
 Default: ``{}``

--- a/scrapy_crawlera/__init__.py
+++ b/scrapy_crawlera/__init__.py
@@ -1,4 +1,4 @@
 from .middleware import CrawleraMiddleware
 
 
-__version__ = '1.4.0'
+__version__ = '1.5.0'

--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -21,6 +21,7 @@ class CrawleraMiddleware(object):
     connection_refused_delay = 90
     preserve_delay = False
     header_prefix = 'X-Crawlera-'
+    conflicting_headers = ('X-Crawlera-Profile', 'X-Crawlera-UA')
 
     _settings = [
         ('apikey', str),
@@ -64,7 +65,7 @@ class CrawleraMiddleware(object):
                 "CrawleraMiddleware: disabling download delays on Scrapy side to optimize delays introduced by Crawlera. "
                 "To avoid this behaviour you can use the CRAWLERA_PRESERVE_DELAY setting but keep in mind that this may slow down the crawl significantly")
 
-        self._headers = self.crawler.settings.get('DEFAULT_CRAWLERA_HEADERS', {}).items()
+        self._headers = self.crawler.settings.get('CRAWLERA_DEFAULT_HEADERS', {}).items()
 
     def _settings_get(self, type_, *a, **kw):
         if type_ is int:
@@ -122,7 +123,7 @@ class CrawleraMiddleware(object):
 
     def process_request(self, request, spider):
         if self._is_enabled_for_request(request):
-            self._set_default_crawlera_headers(request)
+            self._set_crawlera_default_headers(request)
             request.meta['proxy'] = self.url
             request.meta['download_timeout'] = self.download_timeout
             request.headers['Proxy-Authorization'] = self._proxyauth
@@ -221,7 +222,7 @@ class CrawleraMiddleware(object):
         header_name = header_name.decode('utf-8').lower()
         return header_name.startswith(self.header_prefix.lower())
 
-    def _set_default_crawlera_headers(self, request):
+    def _set_crawlera_default_headers(self, request):
         for header, value in self._headers:
             if value is None:
                 continue
@@ -229,9 +230,17 @@ class CrawleraMiddleware(object):
         lower_case_headers = [
             header.decode('utf-8').lower() for header in request.headers
         ]
-        if 'X-Crawlera-Profile'.lower() in lower_case_headers:
+        if all(h.lower() in lower_case_headers for h in self.conflicting_headers):
+            # Send a general warning once, and specific urls if LOG_LEVEL = DEBUG
+            warnings.warn(
+                'The headers %s are conflicting on some of your requests. '
+                'Please check https://doc.scrapinghub.com/crawlera.html '
+                'for more information. You can set LOG_LEVEL=DEBUG to see the urls with problems'
+                % str(self.conflicting_headers)
+            )
             logging.debug(
-                "The header 'X-Crawlera-Profile' is conflicting on request '%s'. 'X-Crawlera-UA' "
-                "will be ignored. Please check https://doc.scrapinghub.com/crawlera.html for more information"
-                % request.url
+                'The headers %s are conflicting on request %s. X-Crawlera-UA '
+                'will be ignored. Please check https://doc.scrapinghub.com/cr'
+                'awlera.html for more information'
+                % (str(self.conflicting_headers), request.url)
             )

--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -21,7 +21,6 @@ class CrawleraMiddleware(object):
     connection_refused_delay = 90
     preserve_delay = False
     header_prefix = 'X-Crawlera-'
-    conflicting_headers = ('X-Crawlera-Profile', 'X-Crawlera-UA')
 
     _settings = [
         ('apikey', str),
@@ -65,7 +64,7 @@ class CrawleraMiddleware(object):
                 "CrawleraMiddleware: disabling download delays on Scrapy side to optimize delays introduced by Crawlera. "
                 "To avoid this behaviour you can use the CRAWLERA_PRESERVE_DELAY setting but keep in mind that this may slow down the crawl significantly")
 
-        self._headers = self.crawler.settings.get('CRAWLERA_DEFAULT_HEADERS', {}).items()
+        self._headers = self.crawler.settings.get('DEFAULT_CRAWLERA_HEADERS', {}).items()
 
     def _settings_get(self, type_, *a, **kw):
         if type_ is int:
@@ -123,7 +122,7 @@ class CrawleraMiddleware(object):
 
     def process_request(self, request, spider):
         if self._is_enabled_for_request(request):
-            self._set_crawlera_default_headers(request)
+            self._set_default_crawlera_headers(request)
             request.meta['proxy'] = self.url
             request.meta['download_timeout'] = self.download_timeout
             request.headers['Proxy-Authorization'] = self._proxyauth
@@ -222,7 +221,7 @@ class CrawleraMiddleware(object):
         header_name = header_name.decode('utf-8').lower()
         return header_name.startswith(self.header_prefix.lower())
 
-    def _set_crawlera_default_headers(self, request):
+    def _set_default_crawlera_headers(self, request):
         for header, value in self._headers:
             if value is None:
                 continue
@@ -230,10 +229,9 @@ class CrawleraMiddleware(object):
         lower_case_headers = [
             header.decode('utf-8').lower() for header in request.headers
         ]
-        if all(h.lower() in lower_case_headers for h in self.conflicting_headers):
-            logging.warn(
-                'The headers %s are conflicting on request %s. X-Crawlera-UA '
-                'will be ignored. Please check https://doc.scrapinghub.com/cr'
-                'awlera.html for more information'
-                % (str(self.conflicting_headers), request.url)
+        if 'X-Crawlera-Profile'.lower() in lower_case_headers:
+            logging.debug(
+                "The header 'X-Crawlera-Profile' is conflicting on request '%s'. 'X-Crawlera-UA' "
+                "will be ignored. Please check https://doc.scrapinghub.com/crawlera.html for more information"
+                % request.url
             )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='scrapy-crawlera',
-    version='1.4.0',
+    version='1.5.0',
     license='BSD',
     description='Crawlera middleware for Scrapy',
     maintainer='Raul Gallegos',

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -390,11 +390,11 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.assertIn(b'X-Crawlera-Profile', req.headers)
         self.assertIn(b'User-Agent', req.headers)
 
-    def test_crawlera_default_headers(self):
+    def test_default_crawlera_headers(self):
         spider = self.spider
         self.spider.crawlera_enabled = True
 
-        self.settings['CRAWLERA_DEFAULT_HEADERS'] = {
+        self.settings['DEFAULT_CRAWLERA_HEADERS'] = {
             'X-Crawlera-Profile': 'desktop',
         }
         crawler = self._mock_crawler(spider, self.settings)
@@ -405,7 +405,7 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.assertEqual(req.headers['X-Crawlera-Profile'], b'desktop')
 
         # test ignore None headers
-        self.settings['CRAWLERA_DEFAULT_HEADERS'] = {
+        self.settings['DEFAULT_CRAWLERA_HEADERS'] = {
             'X-Crawlera-Profile': None,
             'X-Crawlera-Cookies': 'disable',
         }
@@ -418,11 +418,11 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.assertNotIn('X-Crawlera-Profile', req.headers)
 
     @patch('scrapy_crawlera.middleware.logging')
-    def test_crawlera_default_headers_conflicting_headers(self, mock_logger):
+    def test_default_crawlera_headers_conflicting_headers(self, mock_logger):
         spider = self.spider
         self.spider.crawlera_enabled = True
 
-        self.settings['CRAWLERA_DEFAULT_HEADERS'] = {
+        self.settings['DEFAULT_CRAWLERA_HEADERS'] = {
             'X-Crawlera-Profile': 'desktop',
         }
         crawler = self._mock_crawler(spider, self.settings)
@@ -434,11 +434,10 @@ class CrawleraMiddlewareTestCase(TestCase):
         assert mw.process_request(req, spider) is None
         self.assertEqual(req.headers['X-Crawlera-UA'], b'desktop')
         self.assertEqual(req.headers['X-Crawlera-Profile'], b'desktop')
-        mock_logger.warn.assert_called_with(
-            "The headers ('X-Crawlera-Profile', 'X-Crawlera-UA') are conflictin"
-            "g on request http://www.scrapytest.org/other. X-Crawlera-UA will b"
-            "e ignored. Please check https://doc.scrapinghub.com/crawlera.html "
-            "for more information"
+        mock_logger.debug.assert_called_with(
+            "The header 'X-Crawlera-Profile' is conflicting on "
+            "request 'http://www.scrapytest.org/other'. 'X-Crawlera-UA' "
+            "will be ignored. Please check https://doc.scrapinghub.com/crawlera.html for more information"
         )
 
         # test it ignores case
@@ -447,11 +446,10 @@ class CrawleraMiddlewareTestCase(TestCase):
         assert mw.process_request(req, spider) is None
         self.assertEqual(req.headers['X-Crawlera-UA'], b'desktop')
         self.assertEqual(req.headers['X-Crawlera-Profile'], b'desktop')
-        mock_logger.warn.assert_called_with(
-            "The headers ('X-Crawlera-Profile', 'X-Crawlera-UA') are conflictin"
-            "g on request http://www.scrapytest.org/other. X-Crawlera-UA will b"
-            "e ignored. Please check https://doc.scrapinghub.com/crawlera.html "
-            "for more information"
+        mock_logger.debug.assert_called_with(
+            "The header 'X-Crawlera-Profile' is conflicting on "
+            "request 'http://www.scrapytest.org/other'. 'X-Crawlera-UA' "
+            "will be ignored. Please check https://doc.scrapinghub.com/crawlera.html for more information"
         )
 
     def test_dont_proxy_false_does_nothing(self):

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -390,11 +390,11 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.assertIn(b'X-Crawlera-Profile', req.headers)
         self.assertIn(b'User-Agent', req.headers)
 
-    def test_default_crawlera_headers(self):
+    def test_crawlera_default_headers(self):
         spider = self.spider
         self.spider.crawlera_enabled = True
 
-        self.settings['DEFAULT_CRAWLERA_HEADERS'] = {
+        self.settings['CRAWLERA_DEFAULT_HEADERS'] = {
             'X-Crawlera-Profile': 'desktop',
         }
         crawler = self._mock_crawler(spider, self.settings)
@@ -405,7 +405,7 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.assertEqual(req.headers['X-Crawlera-Profile'], b'desktop')
 
         # test ignore None headers
-        self.settings['DEFAULT_CRAWLERA_HEADERS'] = {
+        self.settings['CRAWLERA_DEFAULT_HEADERS'] = {
             'X-Crawlera-Profile': None,
             'X-Crawlera-Cookies': 'disable',
         }
@@ -418,11 +418,11 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.assertNotIn('X-Crawlera-Profile', req.headers)
 
     @patch('scrapy_crawlera.middleware.logging')
-    def test_default_crawlera_headers_conflicting_headers(self, mock_logger):
+    def test_crawlera_default_headers_conflicting_headers(self, mock_logger):
         spider = self.spider
         self.spider.crawlera_enabled = True
 
-        self.settings['DEFAULT_CRAWLERA_HEADERS'] = {
+        self.settings['CRAWLERA_DEFAULT_HEADERS'] = {
             'X-Crawlera-Profile': 'desktop',
         }
         crawler = self._mock_crawler(spider, self.settings)
@@ -435,9 +435,10 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.assertEqual(req.headers['X-Crawlera-UA'], b'desktop')
         self.assertEqual(req.headers['X-Crawlera-Profile'], b'desktop')
         mock_logger.debug.assert_called_with(
-            "The header 'X-Crawlera-Profile' is conflicting on "
-            "request 'http://www.scrapytest.org/other'. 'X-Crawlera-UA' "
-            "will be ignored. Please check https://doc.scrapinghub.com/crawlera.html for more information"
+            "The headers ('X-Crawlera-Profile', 'X-Crawlera-UA') are conflictin"
+            "g on request http://www.scrapytest.org/other. X-Crawlera-UA will b"
+            "e ignored. Please check https://doc.scrapinghub.com/crawlera.html "
+            "for more information"
         )
 
         # test it ignores case
@@ -447,9 +448,10 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.assertEqual(req.headers['X-Crawlera-UA'], b'desktop')
         self.assertEqual(req.headers['X-Crawlera-Profile'], b'desktop')
         mock_logger.debug.assert_called_with(
-            "The header 'X-Crawlera-Profile' is conflicting on "
-            "request 'http://www.scrapytest.org/other'. 'X-Crawlera-UA' "
-            "will be ignored. Please check https://doc.scrapinghub.com/crawlera.html for more information"
+            "The headers ('X-Crawlera-Profile', 'X-Crawlera-UA') are conflictin"
+            "g on request http://www.scrapytest.org/other. X-Crawlera-UA will b"
+            "e ignored. Please check https://doc.scrapinghub.com/crawlera.html "
+            "for more information"
         )
 
     def test_dont_proxy_false_does_nothing(self):


### PR DESCRIPTION
- Fix for using `DEFAULT_CRAWLERA_HEADERS` instead of `CRAWLERA_DEFAULT_HEADERS`
- X-Crawlera-UA warning changed to debug message as it involves showing that on every request
- Version bump for next release