### PR TITLE
Add exponential backoff when No Available Proxies

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -64,6 +64,20 @@ CRAWLERA_DEFAULT_HEADERS
 
 Default: ``{}``
 
-Default headers added only to crawlera requests. Headers defined on ``DEFAULT_REQUEST_HEADERS`` will take precedence as long as the ``CrawleraMiddleware`` is placed after the ``DefaultHeadersMiddleware``*. Headers set on the requests have precedence over the two settings.
+Default headers added only to crawlera requests. Headers defined on ``DEFAULT_REQUEST_HEADERS`` will take precedence as long as the ``CrawleraMiddleware`` is placed after the ``DefaultHeadersMiddleware``. Headers set on the requests have precedence over the two settings.
 
-*This is the default behavior, ``DefaultHeadersMiddleware`` default priority is ``400`` and we recommend ``CrawleraMiddleware`` priority to be ``610``
+* This is the default behavior, ``DefaultHeadersMiddleware`` default priority is ``400`` and we recommend ``CrawleraMiddleware`` priority to be ``610``
+
+CRAWLERA_BACKOFF_STEP
+-----------------------
+
+Default: ``15``
+
+Step size used for calculating exponential backoff according to the formula: ``random.uniform(0, min(max, step * 2 ** attempt))``.
+
+CRAWLERA_BACKOFF_MAX
+-----------------------
+
+Default: ``180``
+
+Max value for exponential backoff as showed in the formula above.

--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -163,7 +163,7 @@ class CrawleraMiddleware(object):
         if self._is_no_available_proxies(response):
             self._set_custom_delay(request, next(self.exp_backoff))
         else:
-            self._reset_noslaves_delay()
+            self.exp_backoff = exp_backoff(self.backoff_step, self.backoff_max)
 
         if self._is_banned(response):
             self._bans[key] += 1
@@ -208,10 +208,6 @@ class CrawleraMiddleware(object):
     def _get_slot(self, request):
         key = self._get_slot_key(request)
         return key, self.crawler.engine.downloader.slots.get(key)
-
-    def _reset_noslaves_delay(self):
-        """Reset the number of attempts due to no available proxies"""
-        self.exp_backoff = exp_backoff(self.backoff_step, self.backoff_max)
 
     def _set_custom_delay(self, request, delay):
         """Set custom delay for slot and save original one."""

--- a/scrapy_crawlera/utils.py
+++ b/scrapy_crawlera/utils.py
@@ -1,0 +1,17 @@
+import math
+import random
+
+
+def exp_backoff(attempt, cap, base):
+    """ Exponential backoff time """
+    # this is a numerically stable version of
+    # min(cap, base * 2 ** attempt)
+    max_attempts = math.log(cap / base, 2)
+    if attempt <= max_attempts:
+        return base * 2 ** attempt
+    return cap
+
+
+def exp_backoff_full_jitter(attempt, cap, base):
+    """ Exponential backoff time with Full Jitter """
+    return random.uniform(0, exp_backoff(attempt, cap, base))

--- a/scrapy_crawlera/utils.py
+++ b/scrapy_crawlera/utils.py
@@ -7,7 +7,7 @@ from itertools import count
 def exp_backoff(step, max):
     """ Exponential backoff time with Full Jitter """
     # this is a numerically stable version of
-    # min(max, step * 2 ** attempt)
+    # random.uniform(0, min(max, step * 2 ** attempt))
     max_attempts = math.log(max / step, 2)
     for attempt in count(0, 1):
         if attempt < max_attempts:

--- a/scrapy_crawlera/utils.py
+++ b/scrapy_crawlera/utils.py
@@ -10,7 +10,7 @@ def exp_backoff(step, max):
     # random.uniform(0, min(max, step * 2 ** attempt))
     max_attempts = math.log(max / step, 2)
     for attempt in count(0, 1):
-        if attempt < max_attempts:
+        if attempt <= max_attempts:
             yield random.uniform(0, step * 2 ** attempt)
         else:
             yield random.uniform(0, max)

--- a/scrapy_crawlera/utils.py
+++ b/scrapy_crawlera/utils.py
@@ -1,17 +1,16 @@
 import math
 import random
 
-
-def exp_backoff(attempt, cap, base):
-    """ Exponential backoff time """
-    # this is a numerically stable version of
-    # min(cap, base * 2 ** attempt)
-    max_attempts = math.log(cap / base, 2)
-    if attempt <= max_attempts:
-        return base * 2 ** attempt
-    return cap
+from itertools import count
 
 
-def exp_backoff_full_jitter(attempt, cap, base):
+def exp_backoff(step, max):
     """ Exponential backoff time with Full Jitter """
-    return random.uniform(0, exp_backoff(attempt, cap, base))
+    # this is a numerically stable version of
+    # min(max, step * 2 ** attempt)
+    max_attempts = math.log(max / step, 2)
+    for attempt in count(0, 1):
+        if attempt < max_attempts:
+            yield random.uniform(0, step * 2 ** attempt)
+        else:
+            yield random.uniform(0, max)

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -503,6 +503,7 @@ class CrawleraMiddlewareTestCase(TestCase):
         # delays grow exponentially
         mw.process_response(noslaves_req, noslaves_res, self.spider)
         self.assertEqual(slot.delay, backoff_step)
+
         mw.process_response(noslaves_req, noslaves_res, self.spider)
         self.assertEqual(slot.delay, backoff_step * 2 ** 1)
 

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -469,7 +469,11 @@ class CrawleraMiddlewareTestCase(TestCase):
         res = Response(req.url, status=503, headers={'X-Crawlera-Error': 'banned'})
         self.assertTrue(mw._is_banned(res))
 
-    def test_no_proxies_delays(self):
+    @patch('random.uniform')
+    def test_no_proxies_delays(self, random_uniform_patch):
+        # mock random.uniform to just return the max delay
+        random_uniform_patch.side_effect = lambda x, y: y
+
         slot_key = 'www.scrapytest.org'
         url = 'http://www.scrapytest.org'
         ban_url = 'http://ban.me'


### PR DESCRIPTION
Recent internal problems when provisioner restart causing spiders to stop working due to been considered bans were fixed on https://github.com/scrapy-plugins/scrapy-crawlera/pull/64 but another issue is that, at the same time scrapy behavior will be to retry with no delay until proxies are available.

This is supposed to help with that by introducing exponential backoff should it encounter `No Available Proxies`, now that I am writing this I am not sure it makes sense, or if we just rather have a bigish delay when that happens? Please opinions.

Also if going with this, I would like opinions on what should be the default values and if we should actually put some as settings. 