### PR TITLE
Enable Crawlera On Demand

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -69,4 +69,9 @@ CRAWLERA_FORCE_ENABLE_ON_HTTP_CODES
 
 Default: ``[]``
 
-List of http resṕmse status codes that when, ``scrapy-crawlera`` gets a response with one of them and is disabled, it should retry the request forcing the middleware to use crawlera and enable crawlera for all requests from that domain.
+List of HTTP response status codes that warrant enabling Crawlera for the
+corresponding domain.
+
+When a response with one of these HTTP status codes is received after a request
+that did not go through Crawlera, the request is retried with Crawlera, and any
+new request to the same domain is also sent through Crawlera.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -63,3 +63,17 @@ CRAWLERA_BACKOFF_MAX
 Default: ``180``
 
 Max value for exponential backoff as showed in the formula above.
+
+CRAWLERA_FORCE_ENABLE_ON_HTTP_CODES
+------------------------------------
+
+Default: ``[]``
+
+List of http resṕmse status codes that when, ``scrapy-crawlera`` gets a response with one of them and is disabled, it should retry the request forcing the middleware to use crawlera (just for that request).
+
+CRAWLERA_FORCE_ENABLE_FOR_ALL_REQUESTS
+---------------------------------------
+
+Default: ``False``
+
+Set this to ``True`` when you want that, after a response with a code set on ``CRAWLERA_FORCE_ENABLE_ON_HTTP_CODES``, ``scrapy-crawlera`` be enabled for all subsequent requests. 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -69,11 +69,4 @@ CRAWLERA_FORCE_ENABLE_ON_HTTP_CODES
 
 Default: ``[]``
 
-List of http resṕmse status codes that when, ``scrapy-crawlera`` gets a response with one of them and is disabled, it should retry the request forcing the middleware to use crawlera (just for that request).
-
-CRAWLERA_FORCE_ENABLE_FOR_ALL_REQUESTS
----------------------------------------
-
-Default: ``False``
-
-Set this to ``True`` when you want that, after a response with a code set on ``CRAWLERA_FORCE_ENABLE_ON_HTTP_CODES``, ``scrapy-crawlera`` be enabled for all subsequent requests. 
+List of http resṕmse status codes that when, ``scrapy-crawlera`` gets a response with one of them and is disabled, it should retry the request forcing the middleware to use crawlera and enable crawlera for all requests from that domain.

--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -252,8 +252,7 @@ class CrawleraMiddleware(object):
         dnscache.pop(urlparse(self.url).hostname, None)
 
     def _should_enable_for_response(self, response):
-        force_enable_on_http_codes = response.meta.get("force_enable_on_http_codes", self.force_enable_on_http_codes)
-        return response.status in force_enable_on_http_codes
+        return response.status in self.force_enable_on_http_codes
 
     def _is_enabled_for_request(self, request):
         domain = self._get_url_domain(request.url)

--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -2,7 +2,11 @@ import os
 import logging
 import warnings
 from collections import defaultdict
-from urllib.parse import urlparse
+
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 from six.moves.urllib.parse import urlparse
 from w3lib.http import basic_auth_header

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -198,8 +198,7 @@ class CrawleraMiddlewareTestCase(TestCase):
         enabled = False
         self.spider.crawlera_enabled = True
         self._assert_disabled(self.spider, self.settings)
-        # Even if disabled, get_proxyauth should be called
-        self.assertEqual(wascalled, ['is_enabled', 'get_proxyauth'])
+        self.assertEqual(wascalled, ['is_enabled'])
 
         wascalled[:] = []  # reset
         enabled = True
@@ -657,22 +656,6 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.assertIsInstance(out, Request)
         self.assertEqual(mw.enabled_for_domain["scrapy.org"], True)
         self.assertEqual(mw.enabled, False)
-
-        mw.enabled_for_domain = {}
-        req = Request(url, meta={"force_enable_on_http_codes": [503]})
-        res = Response(url, status=503, request=req)
-        out = mw.process_response(req, res, self.spider)
-        self.assertIsInstance(out, Request)
-        self.assertEqual(mw.enabled_for_domain["scrapy.org"], True)
-        self.assertEqual(mw.enabled, False)
-
-        mw.enabled_for_domain = {}
-        req = Request(url, meta={"force_enable_on_http_codes": [503]})
-        res = Response(url, status=403, request=req)
-        out = mw.process_response(req, res, self.spider)
-        self.assertIsInstance(out, Response)
-        self.assertEqual(mw.enabled, False)
-        self.assertEqual(mw.enabled_for_domain, {})
 
         # A good response shouldnt enable it
         mw.enabled_for_domain = {}

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -642,25 +642,6 @@ class CrawleraMiddlewareTestCase(TestCase):
         ]
         assert mock_logger.info.call_args_list == expected_calls
 
-    def test_force_proxy(self):
-        self.spider.crawlera_enabled = False
-        crawler = self._mock_crawler(self.spider, self.settings)
-        mw = self.mwcls.from_crawler(crawler)
-        mw.open_spider(self.spider)
-
-        req = Request('http://www.scrapytest.org', meta={"force_proxy": True})
-        assert mw.process_request(req, self.spider) is None
-        self.assertIsNotNone(req.meta.get('proxy'))
-
-        # force_proxy has precedence
-        req = Request('http://www.scrapytest.org', meta={"force_proxy": True, "dont_proxy": True})
-        assert mw.process_request(req, self.spider) is None
-        self.assertIsNotNone(req.meta.get('proxy'))
-
-        req = Request('http://www.scrapytest.org')
-        assert mw.process_request(req, self.spider) is None
-        self.assertIsNone(req.meta.get('proxy'))
-
     def test_process_response_enables_crawlera(self):
         url = "https://scrapy.org"
 


### PR DESCRIPTION
This fixes https://github.com/scrapy-plugins/scrapy-crawlera/issues/32

There are two use cases that would like to enable crawlera on demand

### 1. Broad crawls

On broad crawls you might do requests on multiple websites and only a few of them might be sensitive to crawlers. For these requests you want to retry them with crawlera. The proposed implementation allows you to do it by setting, for example:

`CRAWLERA_FORCE_ENABLE_ON_HTTP_CODES = [503]`

That way the next time the middleware see's a 503, it will retry the request forcing it to use crawlera.


### 2. Specific crawl on less sensitive website

Some websites might be ok with you crawling up to a point, where afterwards it will start giving you bans, in this case you only want to enable crawlera at this point, but enable it for every subsequent request. The proposed implementation allows you to do it by setting, for example:

`CRAWLERA_FORCE_ENABLE_ON_HTTP_CODES = [503]`
`CRAWLERA_FORCE_ENABLE_FOR_ALL_REQUESTS = True`

That way the next time the middleware see's a 503, it will retry the request and enable crawlera for all subsequent requests.


### What this doesn't do

- The proposed feature doesn't try to be smart or to infer what is a ban, that is the developer responsibility, as every website is unique.
- It doesn't go deeper than looking at HTTP codes to figure out if it's a ban, if you need that just enable crawlera for all requests.


*Note: The implementation is backwards compatible, but in case you have the middleware disabled and not configured auth, it will now log a warning*