### PR TITLE
Fix process response getting duplicated requests

### DIFF
--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -233,7 +233,10 @@ class CrawleraMiddleware(object):
         if self._should_enable_for_response(response):
             domain = self._get_url_domain(request.url)
             self.enabled_for_domain[domain] = True
-            return request
+
+            retryreq = request.copy()
+            retryreq.dont_filter = True
+            return retryreq
         return response
 
     def _retry_auth(self, response, request, spider):

--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -30,6 +30,7 @@ class CrawleraMiddleware(object):
     force_enable_on_http_codes = []
     max_auth_retry_times = 10
     enabled_for_domain = {}
+    apikey = ""
 
     _settings = [
         ('apikey', str),
@@ -176,7 +177,7 @@ class CrawleraMiddleware(object):
             return self._handle_not_enabled_response(request, response)
 
         if not self._is_crawlera_response(response):
-            return request
+            return response
 
         key = self._get_slot_key(request)
         self._restore_original_delay(request)

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -734,7 +734,7 @@ class CrawleraMiddlewareTestCase(TestCase):
         )
 
     @patch('scrapy_crawlera.middleware.logging')
-    def test_apikey_warning_force_enable(self, mock_logger):
+    def test_no_apikey_warning_force_enable(self, mock_logger):
         self.spider.crawlera_enabled = False
         settings = {'CRAWLERA_FORCE_ENABLE_ON_HTTP_CODES': [403]}
         crawler = self._mock_crawler(self.spider, settings)
@@ -747,7 +747,7 @@ class CrawleraMiddlewareTestCase(TestCase):
         )
 
     @patch('scrapy_crawlera.middleware.logging')
-    def test_no_apikey_warning_force_enable(self, mock_logger):
+    def test_apikey_warning_force_enable(self, mock_logger):
         self.spider.crawlera_enabled = False
         settings = {
             'CRAWLERA_FORCE_ENABLE_ON_HTTP_CODES': [403],

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -689,7 +689,7 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.assertEqual(mw.crawler.stats.get_value("crawlera/request"), 2)
 
     @patch('scrapy_crawlera.middleware.logging')
-    def test_no_apikey_warning_crawlera_disabled(self, mock_logger):
+    def test_apikey_warning_crawlera_disabled(self, mock_logger):
         self.spider.crawlera_enabled = False
         settings = {}
         crawler = self._mock_crawler(self.spider, settings)
@@ -699,7 +699,7 @@ class CrawleraMiddlewareTestCase(TestCase):
         mock_logger.warning.assert_not_called()
 
     @patch('scrapy_crawlera.middleware.logging')
-    def test_apikey_warning_crawlera_enabled(self, mock_logger):
+    def test_no_apikey_warning_crawlera_enabled(self, mock_logger):
         self.spider.crawlera_enabled = True
         settings = {}
         crawler = self._mock_crawler(self.spider, settings)


### PR DESCRIPTION
Closes
- fixes #76 

This proposed PR changes to return the actual `response` when is not a response from crawlera, fixing the duplicated request (or indefinitely if `dont_filter=True`)