### PR TITLE
Fixed minor issues that would break docs builds/tests

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,7 +105,7 @@ todo_include_todos = False
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -42,7 +42,7 @@ If ``False`` Sets Scrapy's ``DOWNLOAD_DELAY`` to ``0``, making the spider to cra
 respect the provided ``DOWNLOAD_DELAY`` from Scrapy.
 
 CRAWLERA_DEFAULT_HEADERS
------------------------
+------------------------
 
 Default: ``{}``
 


### PR DESCRIPTION
Only warnings. However in `tox.ini` there's `-W` for `sphinx-build` which would treat also warnings as errors.