### PR TITLE
fix#77: protocol in CRAWLERA_URL

### DIFF
--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -63,6 +63,7 @@ class CrawleraMiddleware(object):
         for k, type_ in self._settings:
             setattr(self, k, self._get_setting_value(spider, k, type_))
 
+        self._fix_url_protocol()
         self._headers = self.crawler.settings.get('CRAWLERA_DEFAULT_HEADERS', {}).items()
         self.exp_backoff = exp_backoff(self.backoff_step, self.backoff_max)
 
@@ -118,6 +119,14 @@ class CrawleraMiddleware(object):
                 type_, 'HUBPROXY_' + k.upper(), o))
         return getattr(
             spider, 'crawlera_' + k, getattr(spider, 'hubproxy_' + k, s))
+
+    def _fix_url_protocol(self):
+        if self.url.startswith('https://'):
+            logging.warning('Replacing "https://" with "http://" in CRAWLERA_URL %s' % self.url)
+            self.url = self.url.replace('https://', 'http://')
+        if not self.url.startswith('http://'):
+            logging.warning('Adding "http://" to CRAWLERA_URL %s' % self.url)
+            self.url = 'http://' + self.url
 
     def is_enabled(self, spider):
         """Hook to enable middleware by custom rules."""

--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -122,9 +122,8 @@ class CrawleraMiddleware(object):
 
     def _fix_url_protocol(self):
         if self.url.startswith('https://'):
-            logging.warning('Replacing "https://" with "http://" in CRAWLERA_URL %s' % self.url)
-            self.url = self.url.replace('https://', 'http://')
-        if not self.url.startswith('http://'):
+            logging.warning('CRAWLERA_URL "%s" set with "https://" protocol.' % self.url)
+        elif not self.url.startswith('http://'):
             logging.warning('Adding "http://" to CRAWLERA_URL %s' % self.url)
             self.url = 'http://' + self.url
 

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -152,6 +152,16 @@ class CrawleraMiddlewareTestCase(TestCase):
         self.settings['CRAWLERA_URL'] = 'http://localhost:8010'
         self._assert_enabled(self.spider, self.settings, proxyurl='http://localhost:8010')
 
+    def test_proxyurl_no_protocol(self):
+        self.spider.crawlera_enabled = True
+        self.settings['CRAWLERA_URL'] = 'localhost:8010'
+        self._assert_enabled(self.spider, self.settings, proxyurl='http://localhost:8010')
+
+    def test_proxyurl_https(self):
+        self.spider.crawlera_enabled = True
+        self.settings['CRAWLERA_URL'] = 'https://localhost:8010'
+        self._assert_enabled(self.spider, self.settings, proxyurl='http://localhost:8010')
+
     def test_proxyurl_including_noconnect(self):
         self.spider.crawlera_enabled = True
         self.settings['CRAWLERA_URL'] = 'http://localhost:8010?noconnect'

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -160,7 +160,7 @@ class CrawleraMiddlewareTestCase(TestCase):
     def test_proxyurl_https(self):
         self.spider.crawlera_enabled = True
         self.settings['CRAWLERA_URL'] = 'https://localhost:8010'
-        self._assert_enabled(self.spider, self.settings, proxyurl='http://localhost:8010')
+        self._assert_enabled(self.spider, self.settings, proxyurl='https://localhost:8010')
 
     def test_proxyurl_including_noconnect(self):
         self.spider.crawlera_enabled = True


### PR DESCRIPTION
Fix #77 
Instead of a better exception I log an warning that the URL was updated.
If no protocol is provided, `http://` is set.
If the protocol was `https://` then it is updated to `http://`