### PR TITLE
Use request.meta than response.meta in the middleware

### DIFF
--- a/scrapy_crawlera/middleware.py
+++ b/scrapy_crawlera/middleware.py
@@ -201,7 +201,7 @@ class CrawleraMiddleware(object):
         if self._is_auth_error(response):
             # When crawlera has issues it might not be able to authenticate users
             # we must retry
-            retries = response.meta.get('crawlera_auth_retry_times', 0)
+            retries = request.meta.get('crawlera_auth_retry_times', 0)
             if retries < self.max_auth_retry_times:
                 return self._retry_auth(response, request, spider)
             else:
@@ -257,7 +257,7 @@ class CrawleraMiddleware(object):
             "Retrying crawlera request for authentication issue",
             extra={'spider': self.spider},
         )
-        retries = response.meta.get('crawlera_auth_retry_times', 0) + 1
+        retries = request.meta.get('crawlera_auth_retry_times', 0) + 1
         retryreq = request.copy()
         retryreq.meta['crawlera_auth_retry_times'] = retries
         retryreq.dont_filter = True

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -646,26 +646,26 @@ class CrawleraMiddlewareTestCase(TestCase):
         retry_times = req.meta["crawlera_auth_retry_times"]
         self.assertEqual(retry_times, 1)
 
-        auth_error_response.meta["crawlera_auth_retry_times"] = retry_times
+        auth_error_req.meta["crawlera_auth_retry_times"] = retry_times
         req = mw.process_response(auth_error_req, auth_error_response, self.spider)
         self.assertEqual(slot.delay, backoff_step * 2 ** 1)
         retry_times = req.meta["crawlera_auth_retry_times"]
         self.assertEqual(retry_times, 2)
 
-        auth_error_response.meta["crawlera_auth_retry_times"] = retry_times
+        auth_error_req.meta["crawlera_auth_retry_times"] = retry_times
         req = mw.process_response(auth_error_req, auth_error_response, self.spider)
         self.assertEqual(slot.delay, backoff_step * 2 ** 2)
         retry_times = req.meta["crawlera_auth_retry_times"]
         self.assertEqual(retry_times, 3)
 
-        auth_error_response.meta["crawlera_auth_retry_times"] = retry_times
+        auth_error_req.meta["crawlera_auth_retry_times"] = retry_times
         req = mw.process_response(auth_error_req, auth_error_response, self.spider)
         self.assertEqual(slot.delay, max_delay)
         retry_times = req.meta["crawlera_auth_retry_times"]
         self.assertEqual(retry_times, 4)
 
         # Should return a response when after max number of retries
-        auth_error_response.meta["crawlera_auth_retry_times"] = retry_times
+        auth_error_req.meta["crawlera_auth_retry_times"] = retry_times
         res = mw.process_response(auth_error_req, auth_error_response, self.spider)
         self.assertIsInstance(res, Response)
 

--- a/tests/test_crawlera.py
+++ b/tests/test_crawlera.py
@@ -20,17 +20,6 @@ import os
 from scrapy_crawlera.utils import exp_backoff
 
 
-Response_init_orig = Response.__init__
-
-
-def Response_init_new(self, *args, **kwargs):
-    assert not kwargs.get('request'), 'response objects at this stage shall not be pinned'
-    return Response_init_orig(self, *args, **kwargs)
-
-
-Response.__init__ = Response_init_new
-
-
 class MockedSlot(object):
 
     def __init__(self, delay=0.0):
@@ -46,6 +35,13 @@ class CrawleraMiddlewareTestCase(TestCase):
     def setUp(self):
         self.spider = Spider('foo')
         self.settings = {'CRAWLERA_APIKEY': 'apikey'}
+        Response_init_orig = Response.__init__
+
+        def Response_init_new(self, *args, **kwargs):
+            assert not kwargs.get('request'), 'response objects at this stage shall not be pinned'
+            return Response_init_orig(self, *args, **kwargs)
+
+        Response.__init__ = Response_init_new
 
     def _mock_crawlera_response(self, url, headers=None, **kwargs):
         crawlera_version = choice(("1.36.3-cd5e44", "", None))


### PR DESCRIPTION
Since in Scrapy's downloader middlewares the response objects shall not be pinned (attached to a request object) yet.

Resolves #91.